### PR TITLE
30 handle versioning for publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ reports/
 config.json
 sjournal_config.json
 Pipfile*
+set_env.py
+test.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM python:3.9.10-bullseye
 WORKDIR /app
 
 ARG TEST_ENV=local_repo
+ARG PYPI_REPO_USER=NOTGIVEN
+ARG PYPI_REPO_PASS=NOTGIVEN
 RUN echo ${TEST_ENV}
 
 COPY requirements.txt requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ COPY . .
 
 RUN if [ "$TEST_ENV" = "local_repo" ] ; then pip install -r requirements.txt -r developer_requirements.txt ; else echo "NOT LOCAL REPO" ; fi
 
-RUN if [ "$TEST_ENV" = "local_publish" ] ; then cd publish && sh ./publish_local.sh ; else echo "NOT LOCAL PUBLISH" ; fi
 RUN if [ "$TEST_ENV" = "local_publish" ] ; then pip install -r developer_requirements.txt ; else echo "NOT LOCAL PUBLISH" ; fi
+RUN if [ "$TEST_ENV" = "local_publish" ] ; then cd publish && sh ./publish_local.sh ; else echo "NOT LOCAL PUBLISH" ; fi
 
 RUN if [ "$TEST_ENV" = "remote_publish" ] ; then cd publish && sh ./publish_remote.sh ; else echo "NOT REMOTE PUBLISH" ; fi
 RUN if [ "$TEST_ENV" = "remote_publish" ] ; then pip install -r developer_requirements.txt ; else echo "NOT REMOTE PUBLISH" ; fi

--- a/Jenkinsfile_PublishRemote
+++ b/Jenkinsfile_PublishRemote
@@ -9,7 +9,6 @@ pipeline {
     stages {
         stage('Build and Publish to PyPI') {
             steps {
-                // TODO: Pass PyPI credentials from Jenkins Config into Dockerfile
                 sh "docker build -t sjournal-docker --build-arg TEST_ENV=remote_publish --build-arg PYPI_REPO_USER=$PYPI_REPO_USER --build-arg PYPI_REPO_PASS=$PYPI_REPO_PASS ."
             }
         }

--- a/Jenkinsfile_PublishRemote
+++ b/Jenkinsfile_PublishRemote
@@ -7,16 +7,17 @@ pipeline {
         buildDiscarder(logRotator(numToKeepStr: '10'))
     }
     stages {
-        stage('Build') {
+        stage('Build and Publish to PyPI') {
             steps {
-                sh "docker build -t sjournal-docker --build-arg TEST_ENV=local_publish ."
+                // TODO: Pass PyPI credentials from Jenkins Config into Dockerfile
+                sh "docker build -t sjournal-docker --build-arg TEST_ENV=remote_publish --build-arg PYPI_REPO_USER=$PYPI_REPO_USER --build-arg PYPI_REPO_PASS=$PYPI_REPO_PASS ."
             }
         }
-        stage('Test') {
+        stage('Run Tests on Remote Build') {
             steps {
                 // Run Tests
                 sh 'mkdir -p reports'
-                sh 'docker run -v $WORKSPACE/reports:/app/reports sjournal-docker python -m pytest --test_environment=local_publish'
+                sh 'docker run -v $WORKSPACE/reports:/app/reports sjournal-docker python -m pytest --test_environment=remote_publish'
             }
         }
     }

--- a/Jenkinsfile_PublishRemote
+++ b/Jenkinsfile_PublishRemote
@@ -36,7 +36,7 @@ pipeline {
 
             // Remove all exited containers and volumes
             sh "docker ps -a -q -f status=exited | xargs docker rm -v"
-            // sh "docker system prune --force -a --volumes"
+            sh "docker system prune --force -a --volumes"
         }
         failure {
             sh "echo TODO: Do something on Failure"

--- a/Jenkinsfile_commit
+++ b/Jenkinsfile_commit
@@ -34,11 +34,11 @@ pipeline {
                         reportName: 'Pytest Report'])
 
             // Remove all exited containers and volumes
-            // sh "docker ps -a -q -f status=exited | xargs docker rm -v"
-            sh "docker system prune --force -a --volumes"
+            sh "docker ps -a -q -f status=exited | xargs docker rm -v"
+            // sh "docker system prune --force -a --volumes"
         }
         failure {
-            sh "echo Do something on Failure"
+            sh "echo TODO: Do something on Failure"
         }
     }
 }

--- a/developer_requirements.txt
+++ b/developer_requirements.txt
@@ -2,3 +2,4 @@ pytest>=7.1.0
 setuptools>=60.9.3
 pytest-html>=3.1.1
 semver>=2.13.0
+rich>=12.0.0

--- a/developer_requirements.txt
+++ b/developer_requirements.txt
@@ -1,3 +1,4 @@
 pytest>=7.1.0
 setuptools>=60.9.3
 pytest-html>=3.1.1
+semver>=2.13.0

--- a/publish/publish_local.sh
+++ b/publish/publish_local.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
-python version_utils.py $*
+set -e
+python version_utils.py -l local $*
 python setup.py sdist bdist_wheel && pip install dist/*.whl
 python clean.py

--- a/publish/publish_local.sh
+++ b/publish/publish_local.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
+python version_utils.py $*
 python setup.py sdist bdist_wheel && pip install dist/*.whl
 python clean.py

--- a/publish/publish_remote.sh
+++ b/publish/publish_remote.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+python version_utils.py $*
 python setup.py sdist bdist_wheel
 python upload.py
 python clean.py

--- a/publish/publish_remote.sh
+++ b/publish/publish_remote.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-python version_utils.py $*
+set -e
+python version_utils.py -l remote $*
 python setup.py sdist bdist_wheel
 python upload.py
 python clean.py

--- a/publish/setup.py
+++ b/publish/setup.py
@@ -2,7 +2,7 @@
 import os
 import setuptools
 import json
-from version_utils import bump_version, copy_version_to_package, current_version
+from version_utils import increment_version, copy_version_to_package, get_current_version, get_git_branch
 
 # ======================================================================================================================
 # Fill in this information for each package.
@@ -62,7 +62,11 @@ if PACKAGE_NAME_OVERRIDE is None:
 # ======================================================================================================================
 
 # Bump and copy the version.
-version = current_version(CONFIG_FILE)
+if get_git_branch() == "main":
+    version = increment_version()
+else:
+    version = get_current_version(CONFIG_FILE)
+
 copy_version_to_package(PACKAGE_PATH, version)
 
 # Copy the README into the long description.

--- a/publish/setup.py
+++ b/publish/setup.py
@@ -2,7 +2,7 @@
 import os
 import setuptools
 import json
-from version_utils import increment_version, copy_version_to_package, get_current_version, get_git_branch
+from version_utils import parse_arguments, handle_version, copy_version_to_package, get_current_version, get_git_branch
 
 # ======================================================================================================================
 # Fill in this information for each package.
@@ -61,13 +61,9 @@ if PACKAGE_NAME_OVERRIDE is None:
 # Automatic Package Setup Script.
 # ======================================================================================================================
 
-# Bump and copy the version.
-if get_git_branch() == "main":
-    version = increment_version()
-else:
-    version = get_current_version(CONFIG_FILE)
 
-copy_version_to_package(PACKAGE_PATH, version)
+final_version = get_current_version()
+copy_version_to_package(PACKAGE_PATH, str(final_version))
 
 # Copy the README into the long description.
 with open("../README.md", "r") as f:
@@ -92,7 +88,7 @@ setuptools.setup(
     description=DESCRIPTION,
     long_description=long_description,
     long_description_content_type="text/markdown",
-    version=version,
+    version=str(final_version),
     url=REPO,
     packages=packages,
     package_dir={PACKAGE_NAME: PACKAGE_PATH},

--- a/publish/version_utils.py
+++ b/publish/version_utils.py
@@ -1,38 +1,84 @@
 import json
 import os
+import sys
+import semver
+import subprocess
+import argparse
 
 
-def current_version(config_file: str) -> str:
-    # Open the file and read the version.
-    with open(config_file, "r") as f:
+def parse_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-i', '--increment', action='store', default=None, choices=["major", "minor", "patch", "prerelease", None],
+                        help="Increment the major, minor, patch, or prerelease version")
+
+    parser.add_argument('-s', '--set', action='store', default=None, help="Set a specific version")
+
+    parser.add_argument('-v', '--version', action='store_true', help="Show the current version")
+
+    return parser.parse_args()
+
+
+def get_git_branch():
+    command = "git rev-parse --abbrev-ref HEAD".split()
+    resp = subprocess.check_output(command)
+    branch_name = resp.decode("utf-8").strip()
+    return branch_name
+
+
+def get_current_version():
+    # Read version from config file
+    with open("build_config.json", "r") as f:
         config_object = json.load(f)
-        current_version = config_object["version"]
+        version = semver.VersionInfo.parse(config_object["version"])
 
-    return current_version
+    return version
 
-# Bump the version.
-def bump_version(config_file: str) -> str:
 
-    # Open the file and read the version.
-    with open(config_file, "r") as f:
-        config_object = json.load(f)
-        current_version = config_object["version"]
-        versions = current_version.split(".")
-        versions[-1] = str(int(versions[-1]) + 1)
-        new_version = ".".join(versions)
+def increment_version(part):
 
-    # Write the file back.
-    with open(config_file, "w") as f:
-        config_object["version"] = new_version
-        json.dump(config_object, f, indent=2)
+    # Get the current version
+    current_version = get_current_version()
+    new_version = current_version
+
+    # Increment the version
+    if get_git_branch() != "main":
+        # CONFIRM THAT INCREASING THE VERSION IS OKAY OUTSIDE OF MAIN
+        pass
+    new_version = new_version.next_version(part, prerelease_token="alpha")
+
+    # Update the config file with the new version
+    with open("build_config.json", "r") as confile:
+        config = json.load(confile)
+    with open("build_config.json", "w") as confile:
+        config["version"] = str(new_version)
+        json.dump(config, confile, indent=2)
 
     # Return new version.
-    print("Bumping Version Number: {} -> {}".format(current_version, new_version))
+    print(f"Bumped Version Number: {current_version} -> {new_version}")
     return new_version
 
 
+def set_version(version_string):
+    current_version = get_current_version()
+
+    if semver.VersionInfo.isvalid(version_string):
+        new_version = semver.VersionInfo.parse(version_string)
+
+        # Update the config file with the new version
+        with open("build_config.json", "r") as confile:
+            config = json.load(confile)
+        with open("build_config.json", "w") as confile:
+            config["version"] = str(new_version)
+            json.dump(config, confile, indent=2)
+        print(f"Set Version Number: {current_version} -> {new_version}")
+        return new_version
+    else:
+        print(f"{version_string} is not a valid SemVer value.")
+        exit(1)
+
+
 # Copy the version to the __init__.py file.
-def copy_version_to_package(path: str, v: str):
+def copy_version_to_package(path, version):
     """ Copy the single source of truth version number into the package as well. """
 
     # Copy __version__ to all root-level files in path.
@@ -48,4 +94,14 @@ def copy_version_to_package(path: str, v: str):
                 if "__version__" not in line:
                     new_file.write(line)
                 else:
-                    new_file.write('__version__ = "{}"\n'.format(v))
+                    new_file.write('__version__ = "{}"\n'.format(version))
+
+
+if __name__ == "__main__":
+    args = parse_arguments()
+    if args.version:
+        print(f"Current Version: {str(get_current_version())}")
+    if args.set:
+        set_version(args.set)
+    elif args.increment:
+        increment_version(args.increment)

--- a/src/sjournal/sjournal.py
+++ b/src/sjournal/sjournal.py
@@ -474,7 +474,8 @@ def main():
     args = parse_args()
 
     if args.version:
-        print(__version__)
+        print(f"sjournal v{__version__} (Made by Sam Stuver)")
+
     else:
         journal = SJournal(args)
         journal.run()

--- a/src/sjournal/utilities/arguments.py
+++ b/src/sjournal/utilities/arguments.py
@@ -8,7 +8,7 @@ def parse_args():
 
     subparsers = parser.add_subparsers(dest='command', help='Commands', title='Commands')
     parser.add_argument('-d', '--debug', action='store_true', help="Output to reports/debug.log instead of stdout")
-    parser.add_argument('-v', '--version', action='store_true', help="Show sjournal version")
+    parser.add_argument('-v', '--version', action='store_true', help="Show sjournal information")
 
     # Add command
     parser_add = subparsers.add_parser('add', help='Add a note to the database')

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,4 +1,8 @@
 import pytest
 from src.sjournal import SJournal
 
-# Unit tests for the SJournal, Note, and Utility methods
+# Unit tests for the SJournal, Note, Utility, and Publish methods
+
+
+def test_publish():
+    pass


### PR DESCRIPTION
- Take care of incrementing in `version_utils.py` based on arguments
- Prompt before changing version outside of `main`, and don't publish remote with non-main branch or non-increased version without force
- update CI pipeline for publishing successful builds. PublishRemote job will run upon successful tests from merge into main